### PR TITLE
Improve mobile quiz layout and add progress tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -11,15 +11,17 @@
   .wrap{max-width:980px;margin:32px auto;padding:0 16px;}
   h1{font-size:28px;margin:0 0 6px;}
   .sub{color:var(--muted);margin-bottom:18px}
-  .controls{display:flex;gap:10px;flex-wrap:wrap;margin:16px 0 22px 0;}
-  .btn{background:#212631;border:1px solid #2a2f37;padding:10px 14px;border-radius:10px;color:var(--ink);cursor:pointer}
+  .controls{display:flex;gap:10px;flex-wrap:wrap;margin:16px 0 22px 0;align-items:center;}
+  .control-buttons{display:flex;gap:10px;}
+  .btn{background:#212631;border:1px solid #2a2f37;padding:10px 14px;border-radius:10px;color:var(--ink);cursor:pointer;transition:transform .15s ease, border-color .15s ease;touch-action:manipulation;}
   .btn:hover{border-color:#3b4350}
-  .pill{display:inline-block;background:#1d2330;border:1px solid #30394a;color:var(--muted);padding:6px 10px;border-radius:999px;margin-left:8px;font-size:12px}
+  .btn:active{transform:scale(.97);}
+  .pill{display:inline-flex;align-items:center;justify-content:center;background:#1d2330;border:1px solid #30394a;color:var(--muted);padding:6px 12px;border-radius:999px;margin-left:8px;font-size:12px;min-height:36px}
   .card{background:var(--card);border-radius:14px;padding:16px 16px 12px;margin:12px 0;box-shadow:0 10px 30px rgba(0,0,0,.25);}
   .q{font-weight:700;margin-bottom:10px}
   .pic{margin:8px 0 10px 0; border-radius:12px; overflow:hidden; border:1px solid #2a2f37;}
   .pic img{display:block;width:100%;height:auto;object-fit:contain; background:#0f1216;}
-  .choice{display:block;margin:8px 0;padding:10px 12px;border:1px solid #2a2f37;border-radius:10px;cursor:pointer;transition:.15s;}
+  .choice{display:block;margin:8px 0;padding:10px 12px;border:1px solid #2a2f37;border-radius:10px;cursor:pointer;transition:.15s;touch-action:manipulation;}
   .choice:hover{border-color:#3b4350;transform:translateY(-1px);}
   .choice.correct{background:rgba(31,191,117,.12);border-color:var(--right);}
   .choice.incorrect{background:rgba(255,93,115,.12);border-color:var(--wrong);}
@@ -27,6 +29,28 @@
   .sticky{position:sticky;top:0;background:linear-gradient(180deg, rgba(11,12,16,0.95), rgba(11,12,16,0.75));backdrop-filter:blur(6px);z-index:99;padding:8px 0;margin-bottom:8px}
   .summary{background:#12151a;border:1px dashed #2a2f37;border-radius:12px;padding:14px;margin:20px 0;color:var(--muted)}
   .summary .big{font-size:20px;color:var(--ink);font-weight:800}
+  .progress{display:flex;flex-direction:column;gap:8px;margin-top:6px;}
+  .progress-label{display:flex;justify-content:space-between;font-size:12px;color:var(--muted);text-transform:uppercase;letter-spacing:.08em;}
+  .progress-track{position:relative;height:8px;border-radius:999px;background:#1d2330;overflow:hidden;}
+  .progress-fill{position:absolute;left:0;top:0;bottom:0;width:0%;border-radius:inherit;background:linear-gradient(90deg,var(--accent),#4dd0e1);transition:width .35s ease;}
+
+  @media (prefers-reduced-motion: reduce){
+    .btn, .choice, .progress-fill{transition:none;}
+  }
+
+  @media (max-width: 640px){
+    .wrap{max-width:100%;margin:16px auto;padding:0 12px;}
+    h1{font-size:clamp(20px,6vw,26px);}
+    .sub{font-size:14px;}
+    .controls{flex-direction:column;align-items:stretch;gap:12px;margin-bottom:18px;}
+    .control-buttons{width:100%;flex-direction:column;gap:8px;}
+    .btn{width:100%;padding:12px 14px;font-size:15px;}
+    .pill{margin-left:0;width:100%;font-size:14px;padding:10px 14px;}
+    .progress{margin-top:4px;}
+    .card{margin:10px 0;padding:14px;}
+    .choice{padding:12px 14px;font-size:15px;}
+    .summary{font-size:14px;}
+  }
 </style>
 </head>
 <body>
@@ -35,9 +59,17 @@
     <h1>Exam 1 — Interactive Quiz with Embedded Images</h1>
     <div class="sub">60 questions • MC + True/False • Instant feedback & explanations • Randomized on load • Images embedded for reliable display</div>
     <div class="controls">
-      <button class="btn" id="shuffle">🔀 Shuffle</button>
-      <button class="btn" id="reset">↩️ Reset</button>
-      <div class="pill">Score: <span class="score" id="score">0</span>/<span id="answered">0</span> • Total: <span id="total">0</span></div>
+      <div class="control-buttons">
+        <button class="btn" id="shuffle">🔀 Shuffle</button>
+        <button class="btn" id="reset">↩️ Reset</button>
+      </div>
+      <div class="pill" aria-live="polite">Score: <span class="score" id="score">0</span>/<span id="answered">0</span> • Total: <span id="total">0</span></div>
+    </div>
+    <div class="progress" role="group" aria-labelledby="progressLabelText">
+      <div class="progress-label"><span id="progressPct">0%</span><span id="progressLabelText">Complete</span></div>
+      <div class="progress-track" id="progressTrack" role="progressbar" aria-valuemin="0" aria-valuemax="100" aria-valuenow="0" aria-labelledby="progressLabelText" aria-describedby="progressPct">
+        <div class="progress-fill" id="progressFill"></div>
+      </div>
     </div>
   </div>
   <div id="quiz"></div>
@@ -57,6 +89,9 @@ const ansEl = document.getElementById('answered');
 const totalEl = document.getElementById('total');
 const finalBox = document.getElementById('final');
 const finalText = document.getElementById('finalText');
+const progressFill = document.getElementById('progressFill');
+const progressPct = document.getElementById('progressPct');
+const progressTrack = document.getElementById('progressTrack');
 
 function shuffleArray(arr){ for(let i=arr.length-1;i>0;i--){ const j=Math.floor(Math.random()*(i+1)); [arr[i],arr[j]]=[arr[j],arr[i]]; } }
 
@@ -75,11 +110,25 @@ function prep(){
   });
 }
 
+function updateScoreboard(){
+  scoreEl.textContent = score;
+  ansEl.textContent = answered;
+  const pct = DATA.length ? Math.round((answered/ DATA.length)*100) : 0;
+  progressPct.textContent = pct + '%';
+  if(progressFill){
+    progressFill.style.width = pct + '%';
+  }
+  if(progressTrack){
+    progressTrack.setAttribute('aria-valuenow', pct);
+    progressTrack.setAttribute('aria-valuetext', pct + '% complete');
+  }
+}
+
 function render(){
   quizEl.innerHTML='';
   totalEl.textContent = DATA.length;
   score=0; answered=0;
-  scoreEl.textContent=0; ansEl.textContent=0;
+  updateScoreboard();
   finalBox.style.display='none';
   DATA.forEach((item, idx)=>{
     const card = document.createElement('div');
@@ -98,7 +147,7 @@ function render(){
         if(ci===item.answer){ ch.classList.add('correct'); if(!already){score++; answered++;}}
         else{ ch.classList.add('incorrect'); const all=card.querySelectorAll('.choice'); all[item.answer].classList.add('correct'); if(!already){answered++;}}
         const ex=card.querySelector('.explain'); if(ex){ex.style.display='block';}
-        scoreEl.textContent=score; ansEl.textContent=answered;
+        updateScoreboard();
         if(answered===DATA.length){ showFinal(); }
       });
       card.appendChild(ch);


### PR DESCRIPTION
## Summary
- tune the quiz layout for handheld devices with stacked controls, larger tap targets, and mobile-friendly spacing
- add an accessible progress indicator tied to the score updates and refactor score handling into a dedicated updater

## Testing
- not run (static site)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6914294f020c832184583d4dad1e4915)